### PR TITLE
[release-1.0.X] ci(release-please): try new trigger (#11)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,8 @@
 name: Release Please
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - release-*.*.*
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release-1.0.X`:
 - [ci(release-please): try new trigger (#11)](https://github.com/zaap59/sandbox-release/pull/11)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)